### PR TITLE
Dropping support for Puppet 3, code cleanup

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,13 +2,10 @@ fixtures:
   forge_modules:
     apt:
       repo: 'puppetlabs/apt'
-      ref: '2.4.0'
     concat:
       repo: 'puppetlabs/concat'
-      ref: '2.2.1'
     epel: 'stahnma/epel'
     stdlib:
       repo: 'puppetlabs/stdlib'
-      ref: '4.13.0'
   symlinks:
     amavisd: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .idea
 .librarian
+*.log
 .project
 .rspec_system
 .tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,18 @@ branches:
   only:
   - master
 rvm:
-- 2.0.0
-- 2.1.0
+- 2.1
 - 2.2
+- 2.3
+- 2.4
 env:
   matrix:
-  - PUPPET_GEM_VERSION="~> 3.8"
   - PUPPET_GEM_VERSION="~> 4.0"
+  - PUPPET_GEM_VERSION="~> 5.0"
 matrix:
   fast_finish: true
   exclude:
+  - rvm: 2.1
+    env: PUPPET_GEM_VERSION="~> 5.0"
   - rvm: 2.2
-    env: PUPPET_GEM_VERSION="~> 3.8"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 4.0"
+    env: PUPPET_GEM_VERSION="~> 5.0"

--- a/LICENSE-ASL-2.0
+++ b/LICENSE-ASL-2.0
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,17 +1,17 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    puppetlabs-apt (2.2.2)
-      puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
-    puppetlabs-concat (2.2.0)
+    puppetlabs-apt (4.5.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.16.0)
+    puppetlabs-concat (2.2.1)
       puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
-    puppetlabs-stdlib (4.12.0)
-    stahnma-epel (1.2.2)
+    puppetlabs-stdlib (4.25.1)
+    stahnma-epel (1.3.0)
       puppetlabs-stdlib (>= 3.0.0)
 
 DEPENDENCIES
-  puppetlabs-apt (< 3.0.0, >= 1.8.0)
-  puppetlabs-concat (< 3.0.0, >= 1.1.1)
-  puppetlabs-stdlib (< 4.13.1, >= 1.0.0)
+  puppetlabs-apt (< 5.0.0, >= 1.8.0)
+  puppetlabs-concat (< 3.0.0, >= 2.2.1)
+  puppetlabs-stdlib (< 5.0.0, >= 1.0.0)
   stahnma-epel (< 2.0.0, >= 1.0.2)
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,12 +21,6 @@ PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.disable_documentation
 
-# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
-# http://puppet-lint.com/checks/class_parameter_defaults/
-PuppetLint.configuration.send('disable_class_parameter_defaults')
-# To fix unquoted cases in spec/fixtures/modules/apt/manifests/key.pp
-PuppetLint.configuration.send('disable_unquoted_string_in_case')
-
 PuppetLint.configuration.ignore_paths = exclude_paths
 
 PuppetSyntax.exclude_paths = exclude_paths

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,8 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "genebean/centos-7-rvm-221"
   # config.vm.box = "debian/jessie64"
+  # config.vm.box = "debian/stretch64"
+  # config.vm.box = "ubuntu/bionic64"
   # config.vm.box_check_update = false
   # config.vm.network "forwarded_port", guest: 80, host: 8080
   # config.vm.network "private_network", ip: "192.168.33.10"
@@ -24,6 +26,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "file", source: "vagrant_files/hiera.yaml", destination: "/tmp/hiera.yaml"
   config.vm.provision "shell", path: "vagrant_files/centos7-init.sh"
   # config.vm.provision "shell", path: "vagrant_files/debian-jessie-init.sh"
+  # config.vm.provision "shell", path: "vagrant_files/debian-stretch-init.sh"
+  # config.vm.provision "shell", path: "vagrant_files/ubuntu-bionic-init.sh"
 
   config.vm.synced_folder ".", "/etc/puppetlabs/code/modules/amavisd"
   # config.vm.synced_folder ".", "/etc/puppetlabs/code/modules/amavisd", type: 'rsync'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,14 +1,7 @@
 # == Class: amavisd::config
 #
-# This class takes care of all necessary configuration
-#
-# === Parameters
-#
-# Document parameters here.
-#
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+# This class takes care of all necessary configuration files using options
+# passed to the main *amavisd* class.
 #
 # === Authors
 #
@@ -16,150 +9,146 @@
 #
 # === Copyright
 #
-# Copyright 2016
+# Copyright 2018
 #
 class amavisd::config {
 
-    if ! defined(Class['amavisd']) {
-        fail('You must include the amavisd base class before using any amavisd defined resources')
+  if ! defined(Class['amavisd']) {
+    fail('You must include the amavisd base class before using any amavisd defined resources')
+  }
+
+  $addr_extension_bad_header_maps   = $amavisd::_addr_extension_bad_header_maps
+  $addr_extension_banned_maps       = $amavisd::_addr_extension_banned_maps
+  $addr_extension_spam_maps         = $amavisd::_addr_extension_spam_maps
+  $addr_extension_virus_maps        = $amavisd::_addr_extension_virus_maps
+  $amavis_conf                      = "${amavisd::_config_dir}/${amavisd::_config_file}"
+  $av_scanners                      = $amavisd::_av_scanners
+  $av_scanners_backup               = $amavisd::_av_scanners_backup
+  $bad_header_quarantine_method     = $amavisd::_bad_header_quarantine_method
+  $bad_header_quarantine_to         = $amavisd::_bad_header_quarantine_to
+  $banned_filename_re               = $amavisd::_banned_filename_re
+  $banned_quarantine_to             = $amavisd::_banned_quarantine_to
+  $bounce_killer_score              = $amavisd::_bounce_killer_score
+  $bypass_decode_parts              = $amavisd::_bypass_decode_parts
+  $bypass_spam_checks_maps          = $amavisd::_bypass_spam_checks_maps
+  $bypass_virus_checks_maps         = $amavisd::_bypass_virus_checks_maps
+  $clean_quarantine_method          = $amavisd::_clean_quarantine_method
+  $daemon_chroot_dir                = $amavisd::_daemon_chroot_dir
+  $daemon_group                     = $amavisd::daemon_group
+  $daemon_user                      = $amavisd::daemon_user
+  $db_home                          = $amavisd::_db_home
+  $decoders                         = $amavisd::_decoders
+  $defang_bad_header                = $amavisd::_defang_bad_header
+  $defang_banned                    = $amavisd::_defang_banned
+  $defang_by_ccat                   = $amavisd::_defang_by_ccat
+  $defang_spam                      = $amavisd::_defang_spam
+  $defang_undecipherable            = $amavisd::_defang_undecipherable
+  $defang_virus                     = $amavisd::_defang_virus
+  $do_syslog                        = $amavisd::_do_syslog
+  $dspam                            = $amavisd::_dspam
+  $enable_db                        = $amavisd::_enable_db
+  $enable_dkim_signing              = $amavisd::_enable_dkim_signing
+  $enable_dkim_verification         = $amavisd::_enable_dkim_verification
+  $enable_zmq                       = $amavisd::_enable_zmq
+  $final_bad_header_destiny         = $amavisd::_final_bad_header_destiny
+  $final_banned_destiny             = $amavisd::_final_banned_destiny
+  $final_spam_destiny               = $amavisd::_final_spam_destiny
+  $final_virus_destiny              = $amavisd::_final_virus_destiny
+  $forward_method                   = $amavisd::_forward_method
+  $helpers_home                     = $amavisd::_helpers_home
+  $include_score_sender_maps        = $amavisd::_include_score_sender_maps
+  $inet_socket_bind                 = $amavisd::_inet_socket_bind
+  $inet_socket_port                 = $amavisd::_inet_socket_port
+  $interface_policy                 = $amavisd::_interface_policy
+  $keep_decoded_original_maps       = $amavisd::_keep_decoded_original_maps
+  $local_domains_maps               = $amavisd::_local_domains_maps
+  $lock_file                        = $amavisd::_lock_file
+  $log_level                        = $amavisd::_log_level
+  $log_recip_templ                  = $amavisd::_log_recip_templ
+  $lookup_sql_dsn                   = $amavisd::_lookup_sql_dsn
+  $mailfrom_notify_admin            = $amavisd::_mailfrom_notify_admin
+  $mailfrom_notify_recip            = $amavisd::_mailfrom_notify_recip
+  $mailfrom_notify_spamadmin        = $amavisd::_mailfrom_notify_spamadmin
+  $mailfrom_to_quarantine           = $amavisd::_mailfrom_to_quarantine
+  $max_expansion_quota              = $amavisd::_max_expansion_quota
+  $max_servers                      = $amavisd::_max_servers
+  $maxfiles                         = $amavisd::_maxfiles
+  $maxlevels                        = $amavisd::_maxlevels
+  $min_expansion_quota              = $amavisd::_min_expansion_quota
+  $mydomain                         = $amavisd::_mydomain
+  $myhome                           = $amavisd::_myhome
+  $myhostname                       = $amavisd::_myhostname
+  $mynetworks                       = $amavisd::_mynetworks
+  $nanny_details_level              = $amavisd::_nanny_details_level
+  $notify_method                    = $amavisd::_notify_method
+  $os_fingerprint_method            = $amavisd::_os_fingerprint_method
+  $path                             = $amavisd::_path
+  $penpals_bonus_score              = $amavisd::_penpals_bonus_score
+  $penpals_threshold_high           = $amavisd::_penpals_threshold_high
+  $pid_file                         = $amavisd::_pid_file
+  $policy_bank                      = $amavisd::_policy_bank
+  $quarantine_subdir_levels         = $amavisd::_quarantine_subdir_levels
+  $quarantinedir                    = $amavisd::_quarantinedir
+  $recipient_delimiter              = $amavisd::_recipient_delimiter
+  $redis_logging_key                = $amavisd::_redis_logging_key
+  $redis_logging_queue_size_limit   = $amavisd::_redis_logging_queue_size_limit
+  $release_format                   = $amavisd::_release_format
+  $report_format                    = $amavisd::_report_format
+  $sa_crediblefrom_dsn_cutoff_level = $amavisd::_sa_crediblefrom_dsn_cutoff_level
+  $sa_dsn_cutoff_level              = $amavisd::_sa_dsn_cutoff_level
+  $sa_kill_level_deflt              = $amavisd::_sa_kill_level_deflt
+  $sa_local_tests_only              = $amavisd::_sa_local_tests_only
+  $sa_mail_body_size_limit          = $amavisd::_sa_mail_body_size_limit
+  $sa_quarantine_cutoff_level       = $amavisd::_sa_quarantine_cutoff_level
+  $sa_spam_subject_tag              = $amavisd::_sa_spam_subject_tag
+  $sa_tag2_level_deflt              = $amavisd::_sa_tag2_level_deflt
+  $sa_tag_level_deflt               = $amavisd::_sa_tag_level_deflt
+  $spam_quarantine_to               = $amavisd::_spam_quarantine_to
+  $storage_redis_dsn                = $amavisd::_storage_redis_dsn
+  $storage_sql_dsn                  = $amavisd::_storage_sql_dsn
+  $syslog_facility                  = $amavisd::_syslog_facility
+  $tempbase                         = $amavisd::_tempbase
+  $timestamp_fmt_mysql              = $amavisd::_timestamp_fmt_mysql
+  $tmpdir                           = $amavisd::_tmpdir
+  $unix_socketname                  = $amavisd::_unix_socketname
+  $virus_admin                      = $amavisd::_virus_admin
+  $virus_quarantine_to              = $amavisd::_virus_quarantine_to
+  $warnbadhrecip                    = $amavisd::_warnbadhrecip
+  $warnbadhsender                   = $amavisd::_warnbadhsender
+  $warnbannedrecip                  = $amavisd::_warnbannedrecip
+  $warnvirusrecip                   = $amavisd::_warnvirusrecip
+
+  concat { $amavis_conf:
+    ensure => 'present',
+    backup => false,
+    owner  => 'root',
+    group  => $amavisd::params::root_group,
+    mode   => '0644'
+  }
+
+  concat::fragment { 'amavis_header':
+    target  => $amavis_conf,
+    content => template('amavisd/header.conf.erb'),
+    order   => '01'
+  }
+
+  concat::fragment { 'amavis_main':
+    target  => $amavis_conf,
+    content => template('amavisd/main.conf.erb'),
+    order   => '05'
+  }
+
+  if $include_score_sender_maps {
+    concat::fragment { 'amavis_score_sender_maps':
+      target  => $amavis_conf,
+      content => template('amavisd/score_sender_maps.conf.erb'),
+      order   => '30'
     }
+  }
 
-    $addr_extension_bad_header_maps   = $amavisd::_addr_extension_bad_header_maps
-    $addr_extension_banned_maps       = $amavisd::_addr_extension_banned_maps
-    $addr_extension_spam_maps         = $amavisd::_addr_extension_spam_maps
-    $addr_extension_virus_maps        = $amavisd::_addr_extension_virus_maps
-    $amavis_conf                      = "${amavisd::_config_dir}/${amavisd::_config_file}"
-    $av_scanners                      = $amavisd::_av_scanners
-    $av_scanners_backup               = $amavisd::_av_scanners_backup
-    $bad_header_quarantine_method     = $amavisd::_bad_header_quarantine_method
-    $bad_header_quarantine_to         = $amavisd::_bad_header_quarantine_to
-    $banned_filename_re               = $amavisd::_banned_filename_re
-    $banned_quarantine_to             = $amavisd::_banned_quarantine_to
-    $bounce_killer_score              = $amavisd::_bounce_killer_score
-    $bypass_decode_parts              = $amavisd::_bypass_decode_parts
-    $bypass_spam_checks_maps          = $amavisd::_bypass_spam_checks_maps
-    $bypass_virus_checks_maps         = $amavisd::_bypass_virus_checks_maps
-    $clean_quarantine_method          = $amavisd::_clean_quarantine_method
-    $daemon_chroot_dir                = $amavisd::_daemon_chroot_dir
-    $daemon_group                     = $amavisd::_daemon_group
-    $daemon_user                      = $amavisd::_daemon_user
-    $db_home                          = $amavisd::_db_home
-    $decoders                         = $amavisd::_decoders
-    $defang_bad_header                = $amavisd::_defang_bad_header
-    $defang_banned                    = $amavisd::_defang_banned
-    $defang_by_ccat                   = $amavisd::_defang_by_ccat
-    $defang_spam                      = $amavisd::_defang_spam
-    $defang_undecipherable            = $amavisd::_defang_undecipherable
-    $defang_virus                     = $amavisd::_defang_virus
-    $do_syslog                        = $amavisd::_do_syslog
-    $dspam                            = $amavisd::_dspam
-    $enable_db                        = $amavisd::_enable_db
-    $enable_dkim_signing              = $amavisd::_enable_dkim_signing
-    $enable_dkim_verification         = $amavisd::_enable_dkim_verification
-    $enable_zmq                       = $amavisd::_enable_zmq
-    $final_bad_header_destiny         = $amavisd::_final_bad_header_destiny
-    $final_banned_destiny             = $amavisd::_final_banned_destiny
-    $final_spam_destiny               = $amavisd::_final_spam_destiny
-    $final_virus_destiny              = $amavisd::_final_virus_destiny
-    $forward_method                   = $amavisd::_forward_method
-    $helpers_home                     = $amavisd::_helpers_home
-    $include_score_sender_maps        = $amavisd::_include_score_sender_maps
-    $inet_socket_bind                 = $amavisd::_inet_socket_bind
-    $inet_socket_port                 = $amavisd::_inet_socket_port
-    $interface_policy                 = $amavisd::_interface_policy
-    $keep_decoded_original_maps       = $amavisd::_keep_decoded_original_maps
-    $local_domains_maps               = $amavisd::_local_domains_maps
-    $lock_file                        = $amavisd::_lock_file
-    $log_level                        = $amavisd::_log_level
-    $log_recip_templ                  = $amavisd::_log_recip_templ
-    $lookup_sql_dsn                   = $amavisd::_lookup_sql_dsn
-    $mailfrom_notify_admin            = $amavisd::_mailfrom_notify_admin
-    $mailfrom_notify_recip            = $amavisd::_mailfrom_notify_recip
-    $mailfrom_notify_spamadmin        = $amavisd::_mailfrom_notify_spamadmin
-    $mailfrom_to_quarantine           = $amavisd::_mailfrom_to_quarantine
-    $max_expansion_quota              = $amavisd::_max_expansion_quota
-    $max_servers                      = $amavisd::_max_servers
-    $maxfiles                         = $amavisd::_maxfiles
-    $maxlevels                        = $amavisd::_maxlevels
-    $min_expansion_quota              = $amavisd::_min_expansion_quota
-    $mydomain                         = $amavisd::_mydomain
-    $myhome                           = $amavisd::_myhome
-    $myhostname                       = $amavisd::_myhostname
-    $mynetworks                       = $amavisd::_mynetworks
-    $nanny_details_level              = $amavisd::_nanny_details_level
-    $notify_method                    = $amavisd::_notify_method
-    $os_fingerprint_method            = $amavisd::_os_fingerprint_method
-    $path                             = $amavisd::_path
-    $penpals_bonus_score              = $amavisd::_penpals_bonus_score
-    $penpals_threshold_high           = $amavisd::_penpals_threshold_high
-    $pid_file                         = $amavisd::_pid_file
-    $policy_bank                      = $amavisd::_policy_bank
-    $quarantine_subdir_levels         = $amavisd::_quarantine_subdir_levels
-    $quarantinedir                    = $amavisd::_quarantinedir
-    $recipient_delimiter              = $amavisd::_recipient_delimiter
-    $redis_logging_key                = $amavisd::_redis_logging_key
-    $redis_logging_queue_size_limit   = $amavisd::_redis_logging_queue_size_limit
-    $release_format                   = $amavisd::_release_format
-    $report_format                    = $amavisd::_report_format
-    $sa_crediblefrom_dsn_cutoff_level = $amavisd::_sa_crediblefrom_dsn_cutoff_level
-    $sa_dsn_cutoff_level              = $amavisd::_sa_dsn_cutoff_level
-    $sa_kill_level_deflt              = $amavisd::_sa_kill_level_deflt
-    $sa_local_tests_only              = $amavisd::_sa_local_tests_only
-    $sa_mail_body_size_limit          = $amavisd::_sa_mail_body_size_limit
-    $sa_quarantine_cutoff_level       = $amavisd::_sa_quarantine_cutoff_level
-    $sa_spam_subject_tag              = $amavisd::_sa_spam_subject_tag
-    $sa_tag2_level_deflt              = $amavisd::_sa_tag2_level_deflt
-    $sa_tag_level_deflt               = $amavisd::_sa_tag_level_deflt
-    $spam_quarantine_to               = $amavisd::_spam_quarantine_to
-    $storage_redis_dsn                = $amavisd::_storage_redis_dsn
-    $storage_sql_dsn                  = $amavisd::_storage_sql_dsn
-    $syslog_facility                  = $amavisd::_syslog_facility
-    $tempbase                         = $amavisd::_tempbase
-    $timestamp_fmt_mysql              = $amavisd::_timestamp_fmt_mysql
-    $tmpdir                           = $amavisd::_tmpdir
-    $unix_socketname                  = $amavisd::_unix_socketname
-    $virus_admin                      = $amavisd::_virus_admin
-    $virus_quarantine_to              = $amavisd::_virus_quarantine_to
-    $warnbadhrecip                    = $amavisd::_warnbadhrecip
-    $warnbadhsender                   = $amavisd::_warnbadhsender
-    $warnbannedrecip                  = $amavisd::_warnbannedrecip
-    $warnvirusrecip                   = $amavisd::_warnvirusrecip
-
-    concat { $amavis_conf:
-        ensure => 'present',
-        backup => false,
-        owner  => 'root',
-        group  => $amavisd::params::root_group,
-        mode   => '0644'
-    }
-
-    concat::fragment { 'amavis_header':
-        target  => $amavis_conf,
-        content => template('amavisd/header.conf.erb'),
-        order   => '01'
-    }
-
-    concat::fragment { 'amavis_main':
-        target  => $amavis_conf,
-        content => template('amavisd/main.conf.erb'),
-        order   => '05'
-    }
-
-    if $include_score_sender_maps {
-        concat::fragment { 'amavis_score_sender_maps':
-            target  => $amavis_conf,
-            content => template('amavisd/score_sender_maps.conf.erb'),
-            order   => '30'
-        }
-    }
-
-    concat::fragment { 'amavis_footer':
-        target  => $amavis_conf,
-        content => template('amavisd/footer.conf.erb'),
-        order   => '99'
-    }
-
-    #sender_scores
-    #clamd.d/amavisd.conf
-    #sysconfig, sysconfig/clamd.amavisd?
+  concat::fragment { 'amavis_footer':
+    target  => $amavis_conf,
+    content => template('amavisd/footer.conf.erb'),
+    order   => '99'
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,28 +5,171 @@
 #
 # === Parameters
 #
-# Document parameters here.
+#  clamd_service - The name of the clamd service if Amavisd is being used in
+#    in conjuction with Clamd.
+#    Default: OS-dependent - see params.pp
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+#  config_dir - The directory where the Amavisd configuration files live.
+#    Default: OS-dependent - see params.pp
 #
-# === Variables
+#  config_file - The name of the configuration file this module will write.
+#    Default: OS-dependent - see params.pp
 #
-# Here you should define a list of variables that this module would require.
+#  daemon_group - The group under which the Amavisd service will run.
+#    Note: This will also set the *daemon_group* setting in the Amavisd config.
+#    Default: 'amavis'
 #
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if
-#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should be avoided in favor of class parameters as
-#   of Puppet 2.6.)
+#  daemon_user - The user under which the Amavisd service will run.
+#    Note: This will also set the *daemon_user* setting in the Amavisd config.
+#    Default: 'amavis'
+#
+#  include_score_sender_maps - Determine whether to include the *sender_score_maps*
+#    template in the final config file.
+#    Default: OS-dependent - see params.pp
+#
+#  manage_epel - Whether or not to include the `epel` class for package installations.
+#    Default: OS-dependent - see params.pp
+#
+#  manage_group - If true, create and manage the *$daemon_group* group.
+#    Default: true
+#
+#  manage_user - If true, create and manage the *$daemon_user* user.
+#    Default: true
+#
+#  package_ensure - If true, manage the package(s) needed for Amavisd.
+#    Default: true
+#
+#  package_name - The name of the Amavisd package to install.
+#    Default: 'amavisd-new'
+#
+#  service_enable - If true, enable the service on the system.
+#    Default: true
+#
+#  service_ensure - Ensure that the service is in this state when Puppet runs.
+#    Default: 'running'
+#
+#  service_name - The name of the service that Puppet should start/stop.
+#    Default: OS-dependent - see params.pp
+#
+#  state_dir - The directory in which Amavisd stores files when it runs.
+#    Default: OS-dependent - see params.pp
+#
+#  user_shell - The shell to use for the user created if *$manage_user* is true.
+#    Default: nologin (path to nologin is OS-dependent)
+#
+# === Parameters with a one-to-one match to Amavisd config file variables
+#  addr_extension_bad_header_maps
+#  addr_extension_banned_maps
+#  addr_extension_spam_maps
+#  addr_extension_virus_maps
+#  av_scanners
+#  av_scanners_backup
+#  bad_header_quarantine_method
+#  bad_header_quarantine_to
+#  banned_filename_re
+#  banned_quarantine_to
+#  bounce_killer_score
+#  bypass_decode_parts
+#  bypass_spam_checks_maps
+#  bypass_virus_checks_maps
+#  clean_quarantine_method
+#  config_dir
+#  config_file
+#  daemon_chroot_dir
+#  daemon_group
+#  daemon_user
+#  db_home
+#  decoders
+#  defang_bad_header
+#  defang_banned
+#  defang_by_ccat
+#  defang_spam
+#  defang_undecipherable
+#  defang_virus
+#  do_syslog
+#  dspam
+#  enable_db
+#  enable_dkim_signing
+#  enable_dkim_verification
+#  enable_zmq
+#  final_bad_header_destiny
+#  final_banned_destiny
+#  final_spam_destiny
+#  final_virus_destiny
+#  forward_method
+#  helpers_home
+#  inet_socket_bind
+#  inet_socket_port
+#  interface_policy
+#  keep_decoded_original_maps
+#  local_domains_maps
+#  lock_file
+#  log_level
+#  log_recip_templ
+#  lookup_sql_dsn
+#  mailfrom_notify_admin
+#  mailfrom_notify_recip
+#  mailfrom_notify_spamadmin
+#  mailfrom_to_quarantine
+#  manage_epel
+#  manage_group
+#  manage_user
+#  max_expansion_quota
+#  max_servers
+#  maxfiles
+#  maxlevels
+#  min_expansion_quota
+#  mydomain
+#  myhome
+#  myhostname
+#  mynetworks
+#  nanny_details_level
+#  notify_method
+#  os_fingerprint_method
+#  package_ensure
+#  package_name
+#  path
+#  penpals_bonus_score
+#  penpals_threshold_high
+#  pid_file
+#  policy_bank
+#  quarantine_subdir_levels
+#  quarantinedir
+#  recipient_delimiter
+#  redis_logging_key
+#  redis_logging_queue_size_limit
+#  release_format
+#  report_format
+#  sa_crediblefrom_dsn_cutoff_level
+#  sa_dsn_cutoff_level
+#  sa_kill_level_deflt
+#  sa_local_tests_only
+#  sa_mail_body_size_limit
+#  sa_quarantine_cutoff_level
+#  sa_spam_subject_tag
+#  sa_tag2_level_deflt
+#  sa_tag_level_deflt
+#  service_enable
+#  service_ensure
+#  service_name
+#  spam_quarantine_to
+#  state_dir
+#  storage_redis_dsn
+#  storage_sql_dsn
+#  syslog_facility
+#  tempbase
+#  timestamp_fmt_mysql
+#  tmpdir
+#  unix_socketname
+#  virus_admin
+#  virus_quarantine_to
+#  warnbadhrecip
+#  warnbadhsender
+#  warnbannedrecip
+#  warnvirusrecip
+#  watch_clamav
 #
 # === Examples
-#
-#  class { 'amavisd':
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
-#  }
 #
 # === Authors
 #
@@ -34,247 +177,250 @@
 #
 # === Copyright
 #
-# Copyright 2016
+# Copyright 2018
 #
 class amavisd (
-    $addr_extension_bad_header_maps   = undef,
-    $addr_extension_banned_maps       = undef,
-    $addr_extension_spam_maps         = undef,
-    $addr_extension_virus_maps        = undef,
-    $av_scanners                      = undef,
-    $av_scanners_backup               = undef,
-    $bad_header_quarantine_method     = undef,
-    $bad_header_quarantine_to         = undef,
-    $banned_filename_re               = undef,
-    $banned_quarantine_to             = undef,
-    $bounce_killer_score              = undef,
-    $bypass_decode_parts              = undef,
-    $bypass_spam_checks_maps          = undef,
-    $bypass_virus_checks_maps         = undef,
-    $clamd_service                    = undef,
-    $clean_quarantine_method          = undef,
-    $config_dir                       = undef,
-    $config_file                      = undef,
-    $daemon_chroot_dir                = undef,
-    $daemon_group                     = undef,
-    $daemon_user                      = undef,
-    $db_home                          = undef,
-    $decoders                         = undef,
-    $defang_bad_header                = undef,
-    $defang_banned                    = undef,
-    $defang_by_ccat                   = undef,
-    $defang_spam                      = undef,
-    $defang_undecipherable            = undef,
-    $defang_virus                     = undef,
-    $do_syslog                        = undef,
-    $dspam                            = undef,
-    $enable_db                        = undef,
-    $enable_dkim_signing              = undef,
-    $enable_dkim_verification         = undef,
-    $enable_zmq                       = undef,
-    $final_bad_header_destiny         = undef,
-    $final_banned_destiny             = undef,
-    $final_spam_destiny               = undef,
-    $final_virus_destiny              = undef,
-    $forward_method                   = undef,
-    $helpers_home                     = undef,
-    $include_score_sender_maps        = undef,
-    $inet_socket_bind                 = undef,
-    $inet_socket_port                 = undef,
-    $interface_policy                 = undef,
-    $keep_decoded_original_maps       = undef,
-    $local_domains_maps               = undef,
-    $lock_file                        = undef,
-    $log_level                        = undef,
-    $log_recip_templ                  = undef,
-    $lookup_sql_dsn                   = undef,
-    $mailfrom_notify_admin            = undef,
-    $mailfrom_notify_recip            = undef,
-    $mailfrom_notify_spamadmin        = undef,
-    $mailfrom_to_quarantine           = undef,
-    $manage_epel                      = undef,
-    $manage_group                     = undef,
-    $manage_user                      = undef,
-    $max_expansion_quota              = undef,
-    $max_servers                      = undef,
-    $maxfiles                         = undef,
-    $maxlevels                        = undef,
-    $min_expansion_quota              = undef,
-    $mydomain                         = undef,
-    $myhome                           = undef,
-    $myhostname                       = undef,
-    $mynetworks                       = undef,
-    $nanny_details_level              = undef,
-    $notify_method                    = undef,
-    $os_fingerprint_method            = undef,
-    $package_ensure                   = present,
-    $package_name                     = undef,
-    $path                             = undef,
-    $penpals_bonus_score              = undef,
-    $penpals_threshold_high           = undef,
-    $pid_file                         = undef,
-    $policy_bank                      = undef,
-    $quarantine_subdir_levels         = undef,
-    $quarantinedir                    = undef,
-    $recipient_delimiter              = undef,
-    $redis_logging_key                = undef,
-    $redis_logging_queue_size_limit   = undef,
-    $release_format                   = undef,
-    $report_format                    = undef,
-    $sa_crediblefrom_dsn_cutoff_level = undef,
-    $sa_dsn_cutoff_level              = undef,
-    $sa_kill_level_deflt              = undef,
-    $sa_local_tests_only              = undef,
-    $sa_mail_body_size_limit          = undef,
-    $sa_quarantine_cutoff_level       = undef,
-    $sa_spam_subject_tag              = undef,
-    $sa_tag2_level_deflt              = undef,
-    $sa_tag_level_deflt               = undef,
-    $service_enable                   = true,
-    $service_ensure                   = 'running',
-    $service_name                     = undef,
-    $spam_quarantine_to               = undef,
-    $state_dir                        = undef,
-    $storage_redis_dsn                = undef,
-    $storage_sql_dsn                  = undef,
-    $syslog_facility                  = undef,
-    $tempbase                         = undef,
-    $timestamp_fmt_mysql              = undef,
-    $tmpdir                           = undef,
-    $unix_socketname                  = undef,
-    $user_shell                       = undef,
-    $virus_admin                      = undef,
-    $virus_quarantine_to              = undef,
-    $warnbadhrecip                    = undef,
-    $warnbadhsender                   = undef,
-    $warnbannedrecip                  = undef,
-    $warnvirusrecip                   = undef,
-    $watch_clamav                     = false,
+  Optional[String] $clamd_service                     = undef,
+  Optional[String] $config_dir                        = undef,
+  Optional[String] $config_file                       = undef,
+  Optional[String] $daemon_group                      = 'amavis',
+  Optional[String] $daemon_user                       = 'amavis',
+  Optional[Boolean] $include_score_sender_maps        = undef,
+  Optional[Boolean] $manage_epel                      = undef,
+  Boolean $manage_group                               = true,
+  Boolean $manage_user                                = true,
+  Optional[String] $package_ensure                    = 'present',
+  Optional[String] $package_name                      = 'amavisd-new',
+  Boolean $service_enable                             = true,
+  Enum['stopped', 'running'] $service_ensure          = 'running',
+  Optional[String] $service_name                      = undef,
+  Optional[String] $state_dir                         = undef,
+  Optional[String] $user_shell                        = undef,
+  Boolean  $watch_clamav                              = false,
+  # Config file options
+  Optional[Array] $addr_extension_bad_header_maps     = undef,
+  Optional[Array] $addr_extension_banned_maps         = undef,
+  Optional[Array] $addr_extension_spam_maps           = undef,
+  Optional[Array] $addr_extension_virus_maps          = undef,
+  Optional[Array] $av_scanners                        = undef,
+  Optional[Array] $av_scanners_backup                 = undef,
+  Optional[String] $bad_header_quarantine_method      = undef,
+  Optional[Array] $bad_header_quarantine_to           = undef,
+  Optional[Array] $banned_filename_re                 = undef,
+  Optional[Array] $banned_quarantine_to               = undef,
+  Optional[Integer] $bounce_killer_score              = undef,
+  Optional[Integer] $bypass_decode_parts              = undef,
+  Optional[Array] $bypass_spam_checks_maps            = undef,
+  Optional[Array] $bypass_virus_checks_maps           = undef,
+  Optional[String] $clean_quarantine_method           = undef,
+  Optional[String] $daemon_chroot_dir                 = undef,
+  Optional[String] $db_home                           = undef,
+  Optional[Array] $decoders                           = undef,
+  Optional[Integer] $defang_bad_header                = undef,
+  Optional[Integer] $defang_banned                    = undef,
+  Optional[Array] $defang_by_ccat                     = undef,
+  Optional[Integer] $defang_spam                      = undef,
+  Optional[Integer] $defang_undecipherable            = undef,
+  Optional[Integer] $defang_virus                     = undef,
+  Optional[Integer] $do_syslog                        = undef,
+  Optional[String] $dspam                             = undef,
+  Optional[Integer] $enable_db                        = undef,
+  Optional[Integer] $enable_dkim_signing              = undef,
+  Optional[Integer] $enable_dkim_verification         = undef,
+  Optional[Integer] $enable_zmq                       = undef,
+  Optional[String] $final_bad_header_destiny          = undef,
+  Optional[String] $final_banned_destiny              = undef,
+  Optional[String] $final_spam_destiny                = undef,
+  Optional[String] $final_virus_destiny               = undef,
+  Optional[String] $forward_method                    = undef,
+  Optional[String] $helpers_home                      = undef,
+  Optional[String] $inet_socket_bind                  = undef,
+  Optional[Integer] $inet_socket_port                 = undef,
+  Optional[Hash] $interface_policy                    = undef,
+  Optional[Array] $keep_decoded_original_maps         = undef,
+  Optional[Array] $local_domains_maps                 = undef,
+  Optional[String] $lock_file                         = undef,
+  Optional[Integer] $log_level                        = undef,
+  Optional[String] $log_recip_templ                   = undef,
+  Optional[Array] $lookup_sql_dsn                     = undef,
+  Optional[String] $mailfrom_notify_admin             = undef,
+  Optional[String] $mailfrom_notify_recip             = undef,
+  Optional[String] $mailfrom_notify_spamadmin         = undef,
+  Optional[String] $mailfrom_to_quarantine            = undef,
+  Optional[String] $max_expansion_quota               = undef,
+  Optional[Integer] $max_servers                      = undef,
+  Optional[Integer] $maxfiles                         = undef,
+  Optional[Integer] $maxlevels                        = undef,
+  Optional[Integer] $min_expansion_quota              = undef,
+  Optional[String] $mydomain                          = undef,
+  Optional[String] $myhome                            = undef,
+  Optional[String] $myhostname                        = undef,
+  Optional[Array] $mynetworks                         = undef,
+  Optional[Integer] $nanny_details_level              = undef,
+  Optional[String] $notify_method                     = undef,
+  Optional[String] $os_fingerprint_method             = undef,
+  Optional[String] $path                              = undef,
+  Optional[String] $penpals_bonus_score               = undef,
+  Optional[String] $penpals_threshold_high            = undef,
+  Optional[String] $pid_file                          = undef,
+  Optional[Hash] $policy_bank                         = undef,
+  Optional[Integer] $quarantine_subdir_levels         = undef,
+  Optional[String] $quarantinedir                     = undef,
+  Optional[String] $recipient_delimiter               = undef,
+  Optional[String] $redis_logging_key                 = undef,
+  Optional[Integer] $redis_logging_queue_size_limit   = undef,
+  Optional[String] $release_format                    = undef,
+  Optional[String] $report_format                     = undef,
+  Optional[Integer] $sa_crediblefrom_dsn_cutoff_level = undef,
+  Optional[Integer] $sa_dsn_cutoff_level              = undef,
+  Optional[String] $sa_kill_level_deflt               = undef,
+  Optional[Integer] $sa_local_tests_only              = undef,
+  Optional[Integer] $sa_mail_body_size_limit          = undef,
+  Optional[String] $sa_quarantine_cutoff_level        = undef,
+  Optional[String] $sa_spam_subject_tag               = undef,
+  Optional[String] $sa_tag2_level_deflt               = undef,
+  Optional[String] $sa_tag_level_deflt                = undef,
+  Optional[String] $spam_quarantine_to                = undef,
+  Optional[String] $storage_redis_dsn                 = undef,
+  Optional[String] $storage_sql_dsn                   = undef,
+  Optional[String] $syslog_facility                   = undef,
+  Optional[String] $tempbase                          = undef,
+  Optional[String] $timestamp_fmt_mysql               = undef,
+  Optional[String] $tmpdir                            = undef,
+  Optional[String] $unix_socketname                   = undef,
+  Optional[String] $virus_admin                       = undef,
+  Optional[String] $virus_quarantine_to               = undef,
+  Optional[Integer] $warnbadhrecip                    = undef,
+  Optional[Integer] $warnbadhsender                   = undef,
+  Optional[Integer] $warnbannedrecip                  = undef,
+  Optional[Integer] $warnvirusrecip                   = undef,
 ) {
-    include ::amavisd::params
+  include ::amavisd::params
 
-    # Service Settings
-    $_clamd_service = pick($clamd_service, $amavisd::params::clamd_service)
-    $_config_dir    = pick($config_dir, $amavisd::params::config_dir)
-    $_config_file   = pick($config_file, $amavisd::params::config_file)
-    $_manage_epel   = pick($manage_epel, $amavisd::params::manage_epel)
-    $_package_name  = pick($package_name, $amavisd::params::package_name)
-    $_service_name  = pick($service_name, $amavisd::params::service_name)
-    $_state_dir     = pick($state_dir, $amavisd::params::state_dir)
-    $_user_shell    = pick($user_shell, $amavisd::params::user_shell)
+  # Service Settings
+  $_clamd_service             = pick($clamd_service, $amavisd::params::clamd_service)
+  $_config_dir                = pick($config_dir, $amavisd::params::config_dir)
+  $_config_file               = pick($config_file, $amavisd::params::config_file)
+  $_include_score_sender_maps = pick($include_score_sender_maps, $amavisd::params::include_score_sender_maps)
+  $_manage_epel               = pick($manage_epel, $amavisd::params::manage_epel)
+  $_service_name              = pick($service_name, $amavisd::params::service_name)
+  $_state_dir                 = pick($state_dir, $amavisd::params::state_dir)
+  $_user_shell                = pick($user_shell, $amavisd::params::user_shell)
 
-    validate_re($package_ensure, '^(absent|held|installed|latest|present|purged)$')
-    validate_re($service_ensure, '^(running|stopped)$')
+  # Optional[String] $daemon_group                      = 'amavis',
+  # Optional[String] $daemon_user                       = 'amavis',
+  # Boolean $manage_group                               = true,
+  # Boolean $manage_user                                = true,
+  # Optional[String] $package_ensure                    = 'present',
+  # Optional[String] $package_name                      = 'amavisd-new',
+  # Boolean $service_enable                             = true,
+  # Enum['stopped', 'running'] $service_ensure          = 'running',
+  # Boolean  $watch_clamav                              = false,
 
-    # Config settings
-    $_addr_extension_bad_header_maps   = pick_default($addr_extension_bad_header_maps, $amavisd::params::addr_extension_bad_header_maps)
-    $_addr_extension_banned_maps       = pick_default($addr_extension_banned_maps, $amavisd::params::addr_extension_banned_maps)
-    $_addr_extension_spam_maps         = pick_default($addr_extension_spam_maps, $amavisd::params::addr_extension_spam_maps)
-    $_addr_extension_virus_maps        = pick_default($addr_extension_virus_maps, $amavisd::params::addr_extension_virus_maps)
-    $_av_scanners                      = pick_default($av_scanners, $amavisd::params::av_scanners)
-    $_av_scanners_backup               = pick_default($av_scanners_backup, $amavisd::params::av_scanners_backup)
-    $_bad_header_quarantine_method     = pick_default($bad_header_quarantine_method, $amavisd::params::bad_header_quarantine_method)
-    $_bad_header_quarantine_to         = pick_default($bad_header_quarantine_to, $amavisd::params::bad_header_quarantine_to)
-    $_banned_filename_re               = pick_default($banned_filename_re, $amavisd::params::banned_filename_re)
-    $_banned_quarantine_to             = pick_default($banned_quarantine_to, $amavisd::params::banned_quarantine_to)
-    $_bounce_killer_score              = pick_default($bounce_killer_score, $amavisd::params::bounce_killer_score)
-    $_bypass_decode_parts              = pick_default($bypass_decode_parts, $amavisd::params::bypass_decode_parts)
-    $_bypass_spam_checks_maps          = pick_default($bypass_spam_checks_maps, $amavisd::params::bypass_spam_checks_maps)
-    $_bypass_virus_checks_maps         = pick_default($bypass_virus_checks_maps, $amavisd::params::bypass_virus_checks_maps)
-    $_clean_quarantine_method          = pick_default($clean_quarantine_method, $amavisd::params::clean_quarantine_method)
-    $_daemon_chroot_dir                = pick_default($daemon_chroot_dir, $amavisd::params::daemon_chroot_dir)
-    $_daemon_group                     = pick_default($daemon_group, $amavisd::params::daemon_group)
-    $_daemon_user                      = pick_default($daemon_user, $amavisd::params::daemon_user)
-    $_decoders                         = pick_default($decoders, $amavisd::params::decoders)
-    $_db_home                          = pick_default($db_home, $amavisd::params::db_home)
-    $_defang_bad_header                = pick_default($defang_bad_header, $amavisd::params::defang_bad_header)
-    $_defang_banned                    = pick_default($defang_banned, $amavisd::params::defang_banned)
-    $_defang_by_ccat                   = pick_default($defang_by_ccat, $amavisd::params::defang_by_ccat)
-    $_defang_spam                      = pick_default($defang_spam, $amavisd::params::defang_spam)
-    $_defang_undecipherable            = pick_default($defang_undecipherable, $amavisd::params::defang_undecipherable)
-    $_defang_virus                     = pick_default($defang_virus, $amavisd::params::defang_virus)
-    $_do_syslog                        = pick_default($do_syslog, $amavisd::params::do_syslog)
-    $_dspam                            = pick_default($dspam, $amavisd::params::dspam)
-    $_enable_db                        = pick_default($enable_db, $amavisd::params::enable_db)
-    $_enable_dkim_signing              = pick_default($enable_dkim_signing, $amavisd::params::enable_dkim_signing)
-    $_enable_dkim_verification         = pick_default($enable_dkim_verification, $amavisd::params::enable_dkim_verification)
-    $_enable_zmq                       = pick_default($enable_zmq, $amavisd::params::enable_zmq)
-    $_final_bad_header_destiny         = pick_default($final_bad_header_destiny, $amavisd::params::final_bad_header_destiny)
-    $_final_banned_destiny             = pick_default($final_banned_destiny, $amavisd::params::final_banned_destiny)
-    $_final_spam_destiny               = pick_default($final_spam_destiny, $amavisd::params::final_spam_destiny)
-    $_final_virus_destiny              = pick_default($final_virus_destiny, $amavisd::params::final_virus_destiny)
-    $_forward_method                   = pick_default($forward_method, $amavisd::params::forward_method)
-    $_helpers_home                     = pick_default($helpers_home, $amavisd::params::helpers_home)
-    $_include_score_sender_maps        = pick_default($include_score_sender_maps, $amavisd::params::include_score_sender_maps)
-    $_inet_socket_bind                 = pick_default($inet_socket_bind, $amavisd::params::inet_socket_bind)
-    $_inet_socket_port                 = pick_default($inet_socket_port, $amavisd::params::inet_socket_port)
-    $_interface_policy                 = pick_default($interface_policy, $amavisd::params::interface_policy)
-    $_keep_decoded_original_maps       = pick_default($keep_decoded_original_maps, $amavisd::params::keep_decoded_original_maps)
-    $_local_domains_maps               = pick_default($local_domains_maps, $amavisd::params::local_domains_maps)
-    $_lock_file                        = pick($lock_file, "${amavisd::_state_dir}/${amavisd::_service_name}.lock")
-    $_log_level                        = pick_default($log_level, $amavisd::params::log_level)
-    $_log_recip_templ                  = pick_default($log_recip_templ, $amavisd::params::log_recip_templ)
-    $_lookup_sql_dsn                   = pick_default($lookup_sql_dsn, $amavisd::params::lookup_sql_dsn)
-    $_mailfrom_notify_admin            = pick_default($mailfrom_notify_admin, $amavisd::params::mailfrom_notify_admin)
-    $_mailfrom_notify_recip            = pick_default($mailfrom_notify_recip, $amavisd::params::mailfrom_notify_recip)
-    $_mailfrom_notify_spamadmin        = pick_default($mailfrom_notify_spamadmin, $amavisd::params::mailfrom_notify_spamadmin)
-    $_mailfrom_to_quarantine           = pick_default($mailfrom_to_quarantine, $amavisd::params::mailfrom_to_quarantine)
-    $_manage_group                     = pick_default($manage_group, $amavisd::params::manage_group)
-    $_manage_user                      = pick_default($manage_user, $amavisd::params::manage_user)
-    $_max_expansion_quota              = pick_default($max_expansion_quota, $amavisd::params::max_expansion_quota)
-    $_max_servers                      = pick_default($max_servers, $amavisd::params::max_servers)
-    $_maxfiles                         = pick_default($maxfiles, $amavisd::params::maxfiles)
-    $_maxlevels                        = pick_default($maxlevels, $amavisd::params::maxlevels)
-    $_min_expansion_quota              = pick_default($min_expansion_quota, $amavisd::params::min_expansion_quota)
-    $_mydomain                         = pick_default($mydomain, $amavisd::params::mydomain)
-    $_myhome                           = pick_default($myhome, $amavisd::params::myhome)
-    $_myhostname                       = pick_default($myhostname, $amavisd::params::myhostname)
-    $_mynetworks                       = pick_default($mynetworks, $amavisd::params::mynetworks)
-    $_nanny_details_level              = pick_default($nanny_details_level, $amavisd::params::nanny_details_level)
-    $_notify_method                    = pick_default($notify_method, $amavisd::params::notify_method)
-    $_os_fingerprint_method            = pick_default($os_fingerprint_method, $amavisd::params::os_fingerprint_method)
-    $_path                             = pick_default($path, $amavisd::params::path)
-    $_penpals_bonus_score              = pick_default($penpals_bonus_score, $amavisd::params::penpals_bonus_score)
-    $_penpals_threshold_high           = pick_default($penpals_threshold_high, $amavisd::params::penpals_threshold_high)
-    $_pid_file                         = pick($pid_file, "${amavisd::_state_dir}/${amavisd::_service_name}.pid")
-    $_policy_bank                      = pick_default($policy_bank, $amavisd::params::policy_bank)
-    $_quarantine_subdir_levels         = pick_default($quarantine_subdir_levels, $amavisd::params::quarantine_subdir_levels)
-    $_quarantinedir                    = pick_default($quarantinedir, $amavisd::params::quarantinedir)
-    $_recipient_delimiter              = pick_default($recipient_delimiter, $amavisd::params::recipient_delimiter)
-    $_redis_logging_key                = pick_default($redis_logging_key, $amavisd::params::redis_logging_key)
-    $_redis_logging_queue_size_limit   = pick_default($redis_logging_queue_size_limit, $amavisd::params::redis_logging_queue_size_limit)
-    $_release_format                   = pick_default($release_format, $amavisd::params::release_format)
-    $_report_format                    = pick_default($report_format, $amavisd::params::report_format)
-    $_sa_crediblefrom_dsn_cutoff_level = pick_default($sa_crediblefrom_dsn_cutoff_level, $amavisd::params::sa_crediblefrom_dsn_cutoff_level)
-    $_sa_dsn_cutoff_level              = pick_default($sa_dsn_cutoff_level, $amavisd::params::sa_dsn_cutoff_level)
-    $_sa_kill_level_deflt              = pick_default($sa_kill_level_deflt, $amavisd::params::sa_kill_level_deflt)
-    $_sa_local_tests_only              = pick_default($sa_local_tests_only, $amavisd::params::sa_local_tests_only)
-    $_sa_mail_body_size_limit          = pick_default($sa_mail_body_size_limit, $amavisd::params::sa_mail_body_size_limit)
-    $_sa_quarantine_cutoff_level       = pick_default($sa_quarantine_cutoff_level, $amavisd::params::sa_quarantine_cutoff_level)
-    $_sa_spam_subject_tag              = pick_default($sa_spam_subject_tag, $amavisd::params::sa_spam_subject_tag)
-    $_sa_tag2_level_deflt              = pick_default($sa_tag2_level_deflt, $amavisd::params::sa_tag2_level_deflt)
-    $_sa_tag_level_deflt               = pick_default($sa_tag_level_deflt, $amavisd::params::sa_tag_level_deflt)
-    $_spam_quarantine_to               = pick_default($spam_quarantine_to, $amavisd::params::spam_quarantine_to)
-    $_storage_redis_dsn                = pick_default($storage_redis_dsn, $amavisd::params::storage_redis_dsn)
-    $_storage_sql_dsn                  = pick_default($storage_sql_dsn, $amavisd::params::storage_sql_dsn)
-    $_syslog_facility                  = pick_default($syslog_facility, $amavisd::params::syslog_facility)
-    $_tempbase                         = pick_default($tempbase, $amavisd::params::tempbase)
-    $_timestamp_fmt_mysql              = pick_default($timestamp_fmt_mysql, $amavisd::params::timestamp_fmt_mysql)
-    $_tmpdir                           = pick_default($tmpdir, $amavisd::params::tmpdir)
-    $_unix_socketname                  = pick($unix_socketname, "${amavisd::_state_dir}/${amavisd::_service_name}.sock")
-    $_virus_admin                      = pick_default($virus_admin, $amavisd::params::virus_admin)
-    $_virus_quarantine_to              = pick_default($virus_quarantine_to, $amavisd::params::virus_quarantine_to)
-    $_warnbadhrecip                    = pick_default($warnbadhrecip, $amavisd::params::warnbadhrecip)
-    $_warnbadhsender                   = pick_default($warnbadhsender, $amavisd::params::warnbadhsender)
-    $_warnbannedrecip                  = pick_default($warnbannedrecip, $amavisd::params::warnbannedrecip)
-    $_warnvirusrecip                   = pick_default($warnvirusrecip, $amavisd::params::warnvirusrecip)
+  # Config settings
+  $_addr_extension_bad_header_maps   = pick_default($addr_extension_bad_header_maps, $amavisd::params::addr_extension_bad_header_maps)
+  $_addr_extension_banned_maps       = pick_default($addr_extension_banned_maps, $amavisd::params::addr_extension_banned_maps)
+  $_addr_extension_spam_maps         = pick_default($addr_extension_spam_maps, $amavisd::params::addr_extension_spam_maps)
+  $_addr_extension_virus_maps        = pick_default($addr_extension_virus_maps, $amavisd::params::addr_extension_virus_maps)
+  $_av_scanners                      = pick_default($av_scanners, $amavisd::params::av_scanners)
+  $_av_scanners_backup               = pick_default($av_scanners_backup, $amavisd::params::av_scanners_backup)
+  $_bad_header_quarantine_method     = pick_default($bad_header_quarantine_method, $amavisd::params::bad_header_quarantine_method)
+  $_bad_header_quarantine_to         = pick_default($bad_header_quarantine_to, $amavisd::params::bad_header_quarantine_to)
+  $_banned_filename_re               = pick_default($banned_filename_re, $amavisd::params::banned_filename_re)
+  $_banned_quarantine_to             = pick_default($banned_quarantine_to, $amavisd::params::banned_quarantine_to)
+  $_bounce_killer_score              = pick_default($bounce_killer_score, $amavisd::params::bounce_killer_score)
+  $_bypass_decode_parts              = pick_default($bypass_decode_parts, $amavisd::params::bypass_decode_parts)
+  $_bypass_spam_checks_maps          = pick_default($bypass_spam_checks_maps, $amavisd::params::bypass_spam_checks_maps)
+  $_bypass_virus_checks_maps         = pick_default($bypass_virus_checks_maps, $amavisd::params::bypass_virus_checks_maps)
+  $_clean_quarantine_method          = pick_default($clean_quarantine_method, $amavisd::params::clean_quarantine_method)
+  $_daemon_chroot_dir                = pick_default($daemon_chroot_dir, $amavisd::params::daemon_chroot_dir)
+  $_decoders                         = pick_default($decoders, $amavisd::params::decoders)
+  $_db_home                          = pick_default($db_home, $amavisd::params::db_home)
+  $_defang_bad_header                = pick_default($defang_bad_header, $amavisd::params::defang_bad_header)
+  $_defang_banned                    = pick_default($defang_banned, $amavisd::params::defang_banned)
+  $_defang_by_ccat                   = pick_default($defang_by_ccat, $amavisd::params::defang_by_ccat)
+  $_defang_spam                      = pick_default($defang_spam, $amavisd::params::defang_spam)
+  $_defang_undecipherable            = pick_default($defang_undecipherable, $amavisd::params::defang_undecipherable)
+  $_defang_virus                     = pick_default($defang_virus, $amavisd::params::defang_virus)
+  $_do_syslog                        = pick_default($do_syslog, $amavisd::params::do_syslog)
+  $_dspam                            = pick_default($dspam, $amavisd::params::dspam)
+  $_enable_db                        = pick_default($enable_db, $amavisd::params::enable_db)
+  $_enable_dkim_signing              = pick_default($enable_dkim_signing, $amavisd::params::enable_dkim_signing)
+  $_enable_dkim_verification         = pick_default($enable_dkim_verification, $amavisd::params::enable_dkim_verification)
+  $_enable_zmq                       = pick_default($enable_zmq, $amavisd::params::enable_zmq)
+  $_final_bad_header_destiny         = pick_default($final_bad_header_destiny, $amavisd::params::final_bad_header_destiny)
+  $_final_banned_destiny             = pick_default($final_banned_destiny, $amavisd::params::final_banned_destiny)
+  $_final_spam_destiny               = pick_default($final_spam_destiny, $amavisd::params::final_spam_destiny)
+  $_final_virus_destiny              = pick_default($final_virus_destiny, $amavisd::params::final_virus_destiny)
+  $_forward_method                   = pick_default($forward_method, $amavisd::params::forward_method)
+  $_helpers_home                     = pick_default($helpers_home, $amavisd::params::helpers_home)
+  $_inet_socket_bind                 = pick_default($inet_socket_bind, $amavisd::params::inet_socket_bind)
+  $_inet_socket_port                 = pick_default($inet_socket_port, $amavisd::params::inet_socket_port)
+  $_interface_policy                 = pick_default($interface_policy, $amavisd::params::interface_policy)
+  $_keep_decoded_original_maps       = pick_default($keep_decoded_original_maps, $amavisd::params::keep_decoded_original_maps)
+  $_local_domains_maps               = pick_default($local_domains_maps, $amavisd::params::local_domains_maps)
+  $_lock_file                        = pick($lock_file, "${amavisd::_state_dir}/${amavisd::_service_name}.lock")
+  $_log_level                        = pick_default($log_level, $amavisd::params::log_level)
+  $_log_recip_templ                  = pick_default($log_recip_templ, $amavisd::params::log_recip_templ)
+  $_lookup_sql_dsn                   = pick_default($lookup_sql_dsn, $amavisd::params::lookup_sql_dsn)
+  $_mailfrom_notify_admin            = pick_default($mailfrom_notify_admin, $amavisd::params::mailfrom_notify_admin)
+  $_mailfrom_notify_recip            = pick_default($mailfrom_notify_recip, $amavisd::params::mailfrom_notify_recip)
+  $_mailfrom_notify_spamadmin        = pick_default($mailfrom_notify_spamadmin, $amavisd::params::mailfrom_notify_spamadmin)
+  $_mailfrom_to_quarantine           = pick_default($mailfrom_to_quarantine, $amavisd::params::mailfrom_to_quarantine)
+  $_max_expansion_quota              = pick_default($max_expansion_quota, $amavisd::params::max_expansion_quota)
+  $_max_servers                      = pick_default($max_servers, $amavisd::params::max_servers)
+  $_maxfiles                         = pick_default($maxfiles, $amavisd::params::maxfiles)
+  $_maxlevels                        = pick_default($maxlevels, $amavisd::params::maxlevels)
+  $_min_expansion_quota              = pick_default($min_expansion_quota, $amavisd::params::min_expansion_quota)
+  $_mydomain                         = pick_default($mydomain, $amavisd::params::mydomain)
+  $_myhome                           = pick_default($myhome, $amavisd::params::myhome)
+  $_myhostname                       = pick_default($myhostname, $amavisd::params::myhostname)
+  $_mynetworks                       = pick_default($mynetworks, $amavisd::params::mynetworks)
+  $_nanny_details_level              = pick_default($nanny_details_level, $amavisd::params::nanny_details_level)
+  $_notify_method                    = pick_default($notify_method, $amavisd::params::notify_method)
+  $_os_fingerprint_method            = pick_default($os_fingerprint_method, $amavisd::params::os_fingerprint_method)
+  $_path                             = pick_default($path, $amavisd::params::path)
+  $_penpals_bonus_score              = pick_default($penpals_bonus_score, $amavisd::params::penpals_bonus_score)
+  $_penpals_threshold_high           = pick_default($penpals_threshold_high, $amavisd::params::penpals_threshold_high)
+  $_pid_file                         = pick($pid_file, "${amavisd::_state_dir}/${amavisd::_service_name}.pid")
+  $_policy_bank                      = pick_default($policy_bank, $amavisd::params::policy_bank)
+  $_quarantine_subdir_levels         = pick_default($quarantine_subdir_levels, $amavisd::params::quarantine_subdir_levels)
+  $_quarantinedir                    = pick_default($quarantinedir, $amavisd::params::quarantinedir)
+  $_recipient_delimiter              = pick_default($recipient_delimiter, $amavisd::params::recipient_delimiter)
+  $_redis_logging_key                = pick_default($redis_logging_key, $amavisd::params::redis_logging_key)
+  $_redis_logging_queue_size_limit   = pick_default($redis_logging_queue_size_limit, $amavisd::params::redis_logging_queue_size_limit)
+  $_release_format                   = pick_default($release_format, $amavisd::params::release_format)
+  $_report_format                    = pick_default($report_format, $amavisd::params::report_format)
+  $_sa_crediblefrom_dsn_cutoff_level = pick_default($sa_crediblefrom_dsn_cutoff_level, $amavisd::params::sa_crediblefrom_dsn_cutoff_level)
+  $_sa_dsn_cutoff_level              = pick_default($sa_dsn_cutoff_level, $amavisd::params::sa_dsn_cutoff_level)
+  $_sa_kill_level_deflt              = pick_default($sa_kill_level_deflt, $amavisd::params::sa_kill_level_deflt)
+  $_sa_local_tests_only              = pick_default($sa_local_tests_only, $amavisd::params::sa_local_tests_only)
+  $_sa_mail_body_size_limit          = pick_default($sa_mail_body_size_limit, $amavisd::params::sa_mail_body_size_limit)
+  $_sa_quarantine_cutoff_level       = pick_default($sa_quarantine_cutoff_level, $amavisd::params::sa_quarantine_cutoff_level)
+  $_sa_spam_subject_tag              = pick_default($sa_spam_subject_tag, $amavisd::params::sa_spam_subject_tag)
+  $_sa_tag2_level_deflt              = pick_default($sa_tag2_level_deflt, $amavisd::params::sa_tag2_level_deflt)
+  $_sa_tag_level_deflt               = pick_default($sa_tag_level_deflt, $amavisd::params::sa_tag_level_deflt)
+  $_spam_quarantine_to               = pick_default($spam_quarantine_to, $amavisd::params::spam_quarantine_to)
+  $_storage_redis_dsn                = pick_default($storage_redis_dsn, $amavisd::params::storage_redis_dsn)
+  $_storage_sql_dsn                  = pick_default($storage_sql_dsn, $amavisd::params::storage_sql_dsn)
+  $_syslog_facility                  = pick_default($syslog_facility, $amavisd::params::syslog_facility)
+  $_tempbase                         = pick_default($tempbase, $amavisd::params::tempbase)
+  $_timestamp_fmt_mysql              = pick_default($timestamp_fmt_mysql, $amavisd::params::timestamp_fmt_mysql)
+  $_tmpdir                           = pick_default($tmpdir, $amavisd::params::tmpdir)
+  $_unix_socketname                  = pick($unix_socketname, "${amavisd::_state_dir}/${amavisd::_service_name}.sock")
+  $_virus_admin                      = pick_default($virus_admin, $amavisd::params::virus_admin)
+  $_virus_quarantine_to              = pick_default($virus_quarantine_to, $amavisd::params::virus_quarantine_to)
+  $_warnbadhrecip                    = pick_default($warnbadhrecip, $amavisd::params::warnbadhrecip)
+  $_warnbadhsender                   = pick_default($warnbadhsender, $amavisd::params::warnbadhsender)
+  $_warnbannedrecip                  = pick_default($warnbannedrecip, $amavisd::params::warnbannedrecip)
+  $_warnvirusrecip                   = pick_default($warnvirusrecip, $amavisd::params::warnvirusrecip)
 
-    anchor { 'amavisd::begin': } ->
+  anchor { 'amavisd::begin': }
 
-    class { 'amavisd::repos': } ->
-    class { 'amavisd::install': } ->
-    class { 'amavisd::config': } ->
-    class { 'amavisd::service': } ->
+  -> class { 'amavisd::repos': }
+  -> class { 'amavisd::install': }
+  -> class { 'amavisd::config': }
+  -> class { 'amavisd::service': }
 
-    anchor { 'amavisd::end': }
+  -> anchor { 'amavisd::end': }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,30 +2,17 @@
 #
 # This class takes care of all necessary package installations
 #
-# === Parameters
-#
-# Document parameters here.
-#
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
-#
 # === Variables
 #
-# Here you should define a list of variables that this module would require.
-#
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if
-#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should be avoided in favor of class parameters as
-#   of Puppet 2.6.)
-#
-# === Examples
-#
-#  class { 'amavisd':
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
-#  }
+#  $amavisd::daemon_group
+#  $amavisd::daemon_user
+#  $amavisd::_manage_epel
+#  $amavisd::manage_group
+#  $amavisd::manage_user
+#  $amavisd::_myhome
+#  $amavisd::package_ensure
+#  $amavisd::package_name
+#  $amavisd::user_shell
 #
 # === Authors
 #
@@ -33,68 +20,68 @@
 #
 # === Copyright
 #
-# Copyright 2016
+# Copyright 2018
 #
 class amavisd::install {
 
-    if $::osfamily == 'RedHat' {
-        if ($::operatingsystem != 'Amazon') and ($::operatingsystem != 'Fedora') {
-            if $amavisd::_manage_epel {
-                $pkg_require = Class['epel']
-            } else {
-                $pkg_require = undef
-            }
-        } else {
-            $pkg_require = undef
-        }
-    } else {
+  if $::osfamily == 'RedHat' {
+    if ($::operatingsystem != 'Amazon') and ($::operatingsystem != 'Fedora') {
+      if $amavisd::_manage_epel {
+        $pkg_require = Class['epel']
+      } else {
         $pkg_require = undef
-    }
-
-    if $amavisd::_manage_group {
-        $group_require = Group[$amavisd::_daemon_group]
-
-        group { $amavisd::_daemon_group:
-            ensure => 'present',
-            system => true,
-        }
+      }
     } else {
-        $group_require = undef
+      $pkg_require = undef
     }
+  } else {
+    $pkg_require = undef
+  }
 
-    if $amavisd::_manage_user {
-        $user_require = User[$amavisd::_daemon_user]
+  if $amavisd::manage_group {
+    $group_require = Group[$amavisd::daemon_group]
 
-        user { $amavisd::_daemon_user:
-            ensure     => 'present',
-            comment    => 'User for amavisd-new',
-            forcelocal => true,
-            gid        => $amavisd::_daemon_group,
-            home       => $amavisd::_myhome,
-            managehome => false,
-            shell      => $amavisd::_user_shell,
-            system     => true,
-            require    => $group_require,
-        }
-    } else {
-        $user_require = undef
+    group { $amavisd::daemon_group:
+      ensure => 'present',
+      system => true,
     }
+  } else {
+    $group_require = undef
+  }
 
-    $file_require = unique([$group_require, $user_require])
+  if $amavisd::manage_user {
+    $user_require = User[$amavisd::daemon_user]
 
-    file { $amavisd::_myhome:
-        ensure  => 'directory',
-        owner   => $amavisd::_daemon_user,
-        group   => $amavisd::_daemon_group,
-        mode    => '0750',
-        before  => Package[$amavisd::_package_name],
-        require => $file_require,
+    user { $amavisd::daemon_user:
+      ensure     => 'present',
+      comment    => 'User for amavisd-new',
+      forcelocal => true,
+      gid        => $amavisd::daemon_group,
+      home       => $amavisd::_myhome,
+      managehome => false,
+      shell      => $amavisd::user_shell,
+      system     => true,
+      require    => $group_require,
     }
+  } else {
+    $user_require = undef
+  }
 
-    package { $amavisd::_package_name:
-        ensure  => $amavisd::package_ensure,
-        name    => $amavisd::_package_name,
-        require => $pkg_require,
-        before  => Service['amavisd_service']
-    }
+  $file_require = unique([$group_require, $user_require])
+
+  file { $amavisd::_myhome:
+    ensure  => 'directory',
+    owner   => $amavisd::daemon_user,
+    group   => $amavisd::daemon_group,
+    mode    => '0750',
+    before  => Package[$amavisd::package_name],
+    require => $file_require,
+  }
+
+  package { $amavisd::package_name:
+    ensure  => $amavisd::package_ensure,
+    name    => $amavisd::package_name,
+    require => $pkg_require,
+    before  => Service['amavisd_service']
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,287 +4,272 @@
 #
 # === Variables
 #
-# Here you should define a list of variables that this module would require.
-#
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if
-#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should be avoided in favor of class parameters as
-#   of Puppet 2.6.)
-#
 # === Authors
 #
 # Andrew Teixeira <teixeira@broadinstitute.org>
 #
 # === Copyright
 #
-# Copyright 2016
+# Copyright 2018
 #
 class amavisd::params {
-    # Service settings
-    $clamav_config_dir = '/etc/clamd.d'
-    $daemon_user       = 'amavis'
-    $daemon_group      = 'amavis'
-    $manage_group      = true
-    $manage_user       = true
-    $package_name      = 'amavisd-new'
-    $root_group        = 'root'
+  # System settings
+  $root_group        = 'root'
 
-    # Config settings
-    $av_scanners                    = undef
-    $av_scanners_backup             = undef
-    $bad_header_quarantine_method   = undef
-    $bad_header_quarantine_to       = undef
-    $banned_quarantine_to           = undef
-    $bypass_decode_parts            = []
-    $bypass_spam_checks_maps        = []
-    $bypass_virus_checks_maps       = []
-    $clean_quarantine_method        = undef
-    $daemon_chroot_dir              = undef
-    $defang_bad_header              = undef
-    $defang_spam                    = undef
-    $defang_undecipherable          = undef
-    $dspam                          = undef
-    $enable_zmq                     = undef
-    $forward_method                 = undef
-    $helpers_home                   = undef
-    $log_recip_templ                = undef
-    $lookup_sql_dsn                 = []
-    $mailfrom_notify_admin          = undef
-    $mailfrom_notify_recip          = undef
-    $mailfrom_notify_spamadmin      = undef
-    $mailfrom_to_quarantine         = undef
-    $myhostname                     = undef
-    $notify_method                  = undef
-    $os_fingerprint_method          = undef
-    $quarantine_subdir_levels       = undef
-    $quarantinedir                  = undef
-    $recipient_delimiter            = undef
-    $redis_logging_key              = undef
-    $redis_logging_queue_size_limit = undef
-    $release_format                 = undef
-    $report_format                  = undef
-    $sa_quarantine_cutoff_level     = undef
-    $spam_quarantine_to             = undef
-    $storage_redis_dsn              = []
-    $storage_sql_dsn                = undef
-    $timestamp_fmt_mysql            = undef
-    $virus_admin                    = undef
-    $virus_quarantine_to            = undef
-    $warnbadhrecip                  = undef
-    $warnbadhsender                 = undef
-    $warnbannedrecip                = undef
-    $warnvirusrecip                 = undef
+  # Config settings
+  $av_scanners                    = undef
+  $av_scanners_backup             = undef
+  $bad_header_quarantine_method   = undef
+  $bad_header_quarantine_to       = undef
+  $banned_quarantine_to           = undef
+  $bypass_decode_parts            = undef
+  $bypass_spam_checks_maps        = []
+  $bypass_virus_checks_maps       = []
+  $clean_quarantine_method        = undef
+  $daemon_chroot_dir              = undef
+  $defang_bad_header              = undef
+  $defang_spam                    = undef
+  $defang_undecipherable          = undef
+  $dspam                          = undef
+  $enable_zmq                     = undef
+  $forward_method                 = undef
+  $helpers_home                   = undef
+  $log_recip_templ                = undef
+  $lookup_sql_dsn                 = []
+  $mailfrom_notify_admin          = undef
+  $mailfrom_notify_recip          = undef
+  $mailfrom_notify_spamadmin      = undef
+  $mailfrom_to_quarantine         = undef
+  $myhostname                     = undef
+  $notify_method                  = undef
+  $os_fingerprint_method          = undef
+  $quarantine_subdir_levels       = undef
+  $quarantinedir                  = undef
+  $recipient_delimiter            = undef
+  $redis_logging_key              = undef
+  $redis_logging_queue_size_limit = undef
+  $release_format                 = undef
+  $report_format                  = undef
+  $sa_quarantine_cutoff_level     = undef
+  $spam_quarantine_to             = undef
+  $storage_redis_dsn              = []
+  $storage_sql_dsn                = undef
+  $timestamp_fmt_mysql            = undef
+  $virus_admin                    = undef
+  $virus_quarantine_to            = undef
+  $warnbadhrecip                  = undef
+  $warnbadhsender                 = undef
+  $warnbannedrecip                = undef
+  $warnvirusrecip                 = undef
 
-    case $::osfamily {
-        'Debian': {
-            # Service settings
-            $clamd_service     = 'clamd'
-            $config_dir        = '/etc/amavis/conf.d'
-            $config_file       = '60-puppet'
-            $manage_epel       = false
-            $service_name      = 'amavis'
-            $snmp_package_name = undef
-            $snmp_service_name = undef
-            $state_dir         = '/var/run/amavis'
-            $user_shell        = '/usr/sbin/nologin'
+  case $::osfamily {
+    /^(Debian|Ubuntu)/: {
+      # Service settings
+      $clamd_service     = 'clamd'
+      $config_dir        = '/etc/amavis/conf.d'
+      $config_file       = '60-puppet'
+      $manage_epel       = false
+      $service_name      = 'amavis'
+      $snmp_package_name = undef
+      $snmp_service_name = undef
+      $state_dir         = '/var/run/amavis'
+      $user_shell        = '/usr/sbin/nologin'
 
-            # Config settings
-            $addr_extension_bad_header_maps     = []
-            $addr_extension_banned_maps         = []
-            $addr_extension_spam_maps           = []
-            $addr_extension_virus_maps          = []
-            $banned_filename_re                 = undef
-            $bounce_killer_score                = undef
-            $db_home                            = undef
-            $decoders                           = undef
-            $defang_banned                      = undef
-            $defang_by_ccat                     = []
-            $defang_virus                       = undef
-            $do_syslog                          = undef
-            $enable_db                          = undef
-            $enable_dkim_signing                = undef
-            $enable_dkim_verification           = undef
-            $final_bad_header_destiny           = undef
-            $final_banned_destiny               = undef
-            $final_spam_destiny                 = undef
-            $final_virus_destiny                = undef
-            $include_score_sender_maps          = false
-            $inet_socket_bind                   = undef
-            $inet_socket_port                   = []
-            $interface_policy                   = {}
-            $keep_decoded_original_maps         = []
-            $local_domains_maps                 = []
-            $log_level                          = undef
-            $max_expansion_quota                = undef
-            $max_servers                        = undef
-            $maxfiles                           = undef
-            $maxlevels                          = undef
-            $min_expansion_quota                = undef
-            $mydomain                           = undef
-            $myhome                             = '/var/lib/amavis'
-            $mynetworks                         = []
-            $nanny_details_level                = undef
-            $path                               = undef
-            $penpals_bonus_score                = undef
-            $penpals_threshold_high             = undef
-            $policy_bank                        = {}
-            $sa_crediblefrom_dsn_cutoff_level   = undef
-            $sa_dsn_cutoff_level                = undef
-            $sa_kill_level_deflt                = undef
-            $sa_local_tests_only                = undef
-            $sa_mail_body_size_limit            = undef
-            $sa_spam_subject_tag                = undef
-            $sa_tag2_level_deflt                = undef
-            $sa_tag_level_deflt                 = undef
-            $syslog_facility                    = undef
-            $tempbase                           = undef
-            $tmpdir                             = undef
-        }
-        'RedHat': {
-            # Service settings
-            $clamd_service                      = 'clamd'
-            $config_dir                         = '/etc/amavisd'
-            $config_file                        = 'amavisd.conf'
-            $manage_epel                        = true
-            $service_name                       = 'amavisd'
-            $snmp_package_name                  = 'amavisd-new-snmp'
-            $snmp_service_name                  = 'amavisd-snmp'
-            $state_dir                          = '/var/run/amavisd'
-            $user_shell                         = '/sbin/nologin'
-
-            # Config settings
-            $addr_extension_bad_header_maps     = ['badh' ]
-            $addr_extension_banned_maps         = [ 'banned' ]
-            $addr_extension_spam_maps           = [ 'spam' ]
-            $addr_extension_virus_maps          = [ 'virus' ]
-            $banned_filename_re                 = [
-                "qr'^\\.(exe-ms|dll)$'",
-                "[ qr'^\\.(rpm|cpio|tar)$'       => 0 ]",
-                "qr'.\\.(pif|scr)$'i",
-                "qr'^application/x-msdownload$'i",
-                "qr'^application/x-msdos-program$'i",
-                "qr'^application/hta$'i",
-                "qr'^(?!cid:).*\\.[^./]*[A-Za-z][^./]*\\.\\s*(exe|vbs|pif|scr|bat|cmd|com|cpl|dll)[.\\s]*$'i",
-                "qr'.\\.(exe|vbs|pif|scr|cpl)$'i"
-            ]
-            $bounce_killer_score                = 100
-            $db_home                            = '$MYHOME/db'
-            $decoders                           = [
-                "['mail', \\&do_mime_decode]",
-                "['F',    \\&do_uncompress, ['unfreeze', 'freeze -d', 'melt', 'fcat'] ]",
-                "['Z',    \\&do_uncompress, ['uncompress', 'gzip -d', 'zcat'] ]",
-                "['gz',   \\&do_uncompress, 'gzip -d']",
-                "['gz',   \\&do_gunzip]",
-                "['bz2',  \\&do_uncompress, 'bzip2 -d']",
-                "['xz',   \\&do_uncompress, ['xzdec', 'xz -dc', 'unxz -c', 'xzcat'] ]",
-                "['lzma', \\&do_uncompress, ['lzmadec', 'xz -dc --format=lzma','lzma -dc', 'unlzma -c', 'lzcat', 'lzmadec'] ]",
-                "['lrz',  \\&do_uncompress, ['lrzip -q -k -d -o -', 'lrzcat -q -k'] ]",
-                "['lzo',  \\&do_uncompress, 'lzop -d']",
-                "['lz4',  \\&do_uncompress, ['lz4c -d'] ]",
-                "['rpm',  \\&do_uncompress, ['rpm2cpio.pl', 'rpm2cpio'] ]",
-                "[['cpio','tar'], \\&do_pax_cpio, ['pax', 'gcpio', 'cpio'] ]",
-                "['deb',  \\&do_ar, 'ar']",
-                "['rar',  \\&do_unrar, ['unrar', 'rar'] ]",
-                "['arj',  \\&do_unarj, ['unarj', 'arj'] ]",
-                "['arc',  \\&do_arc,   ['nomarch', 'arc'] ]",
-                "['zoo',  \\&do_zoo,   ['zoo', 'unzoo'] ]",
-                "['cab',  \\&do_cabextract, 'cabextract']",
-                "['tnef', \\&do_tnef]",
-                "[['zip','kmz'], \\&do_7zip,  ['7za', '7z'] ]",
-                "[['zip','kmz'], \\&do_unzip]",
-                "['7z', \\&do_7zip,  ['7zr', '7za', '7z'] ]",
-                "[[qw(gz bz2 Z tar)], \\&do_7zip,  ['7za', '7z'] ]",
-                "[[qw(xz lzma jar cpio arj rar swf lha iso cab deb rpm)], \\&do_7zip,  '7z' ]",
-                "['exe',  \\&do_executable, ['unrar','rar'], 'lha', ['unarj','arj'] ]"
-            ]
-            $defang_banned                      = 1
-            $defang_by_ccat                     = [
-                'CC_BADH.",3"',
-                'CC_BADH.",5"',
-                'CC_BADH.",6"'
-            ]
-            $defang_virus                       = 1
-            $do_syslog                          = 1
-            $enable_db                          = 1
-            $enable_dkim_signing                = 1
-            $enable_dkim_verification           = 1
-            $final_bad_header_destiny           = 'D_BOUNCE'
-            $final_banned_destiny               = 'D_BOUNCE'
-            $final_spam_destiny                 = 'D_DISCARD'
-            $final_virus_destiny                = 'D_DISCARD'
-            $include_score_sender_maps          = true
-            $inet_socket_bind                   = '127.0.0.1'
-            $inet_socket_port                   = [ 10024 ]
-            $interface_policy                   = {
-                '10026' => 'ORIGINATING',
-                'SOCK' => 'AM.PDP-SOCK'
-            }
-            $keep_decoded_original_maps         =  [
-                "qr'^MAIL$'",
-                "qr'^MAIL-UNDECIPHERABLE$'",
-                "qr'^(ASCII(?! cpio)|text|uuencoded|xxencoded|binhex)'i",
-            ]
-            $local_domains_maps                 = [ '.$mydomain' ]
-            $log_level                          = 0
-            $max_expansion_quota                = 500*1024*1024
-            $maxfiles                           = 3000
-            $maxlevels                          = 14
-            $max_servers                        = 2
-            $min_expansion_quota                = '100*1024'
-            $mydomain                           = 'example.com'
-            $myhome                             = '/var/spool/amavisd'
-            $mynetworks                         = [
-                '127.0.0.0/8',
-                '[::1]',
-                '[FE80::]/10',
-                '[FEC0::]/10',
-                '10.0.0.0/8',
-                '172.16.0.0/12',
-                '192.168.0.0/16'
-            ]
-            $nanny_details_level                = 2
-            $path                               = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin'
-            $penpals_bonus_score                = 8
-            $penpals_threshold_high             = '$sa_kill_level_deflt'
-            $policy_bank                        = {
-                'MYNETS' => {
-                    originating           => 1,
-                    os_fingerprint_method => 'undef'
-                },
-                'ORIGINATING' => {
-                    originating                     => 1,
-                    allow_disclaimers               => 1,
-                    virus_admin_maps                => '["virusalert\@$mydomain"]',
-                    spam_admin_maps                 => '["virusalert\@$mydomain"]',
-                    warnbadhsender                  => 1,
-                    forward_method                  => "'smtp:[127.0.0.1]:10027'",
-                    smtpd_discard_ehlo_keywords     => "['8BITMIME']",
-                    bypass_banned_checks_maps       => '[1]',
-                    terminate_dsn_on_notify_success => 0
-                },
-                'AM.PDP-SOCK' => {
-                    protocol => "'AM.PDP'",
-                    auth_required_release => '0'
-                }
-            }
-            $sa_crediblefrom_dsn_cutoff_level   = 18
-            $sa_dsn_cutoff_level                = 10
-            $sa_kill_level_deflt                = '6.9'
-            $sa_local_tests_only                = 0
-            $sa_mail_body_size_limit            = '400*1024'
-            $sa_spam_subject_tag                = '***Spam*** '
-            $sa_tag_level_deflt                 = '2.0'
-            $sa_tag2_level_deflt                = '6.2'
-            $syslog_facility                    = 'mail'
-            $tempbase                           = '$MYHOME/tmp'
-            $tmpdir                             = '$TEMPBASE'
-
-        }
-        default: {
-            fail("Unsupported osfamily: ${::osfamily}")
-        }
+      # Config settings
+      $addr_extension_bad_header_maps     = []
+      $addr_extension_banned_maps         = []
+      $addr_extension_spam_maps           = []
+      $addr_extension_virus_maps          = []
+      $banned_filename_re                 = undef
+      $bounce_killer_score                = undef
+      $db_home                            = undef
+      $decoders                           = undef
+      $defang_banned                      = undef
+      $defang_by_ccat                     = []
+      $defang_virus                       = undef
+      $do_syslog                          = undef
+      $enable_db                          = undef
+      $enable_dkim_signing                = undef
+      $enable_dkim_verification           = undef
+      $final_bad_header_destiny           = undef
+      $final_banned_destiny               = undef
+      $final_spam_destiny                 = undef
+      $final_virus_destiny                = undef
+      $include_score_sender_maps          = false
+      $inet_socket_bind                   = undef
+      $inet_socket_port                   = []
+      $interface_policy                   = {}
+      $keep_decoded_original_maps         = []
+      $local_domains_maps                 = []
+      $log_level                          = undef
+      $max_expansion_quota                = undef
+      $max_servers                        = undef
+      $maxfiles                           = undef
+      $maxlevels                          = undef
+      $min_expansion_quota                = undef
+      $mydomain                           = undef
+      $myhome                             = '/var/lib/amavis'
+      $mynetworks                         = []
+      $nanny_details_level                = undef
+      $path                               = undef
+      $penpals_bonus_score                = undef
+      $penpals_threshold_high             = undef
+      $policy_bank                        = {}
+      $sa_crediblefrom_dsn_cutoff_level   = undef
+      $sa_dsn_cutoff_level                = undef
+      $sa_kill_level_deflt                = undef
+      $sa_local_tests_only                = undef
+      $sa_mail_body_size_limit            = undef
+      $sa_spam_subject_tag                = undef
+      $sa_tag2_level_deflt                = undef
+      $sa_tag_level_deflt                 = undef
+      $syslog_facility                    = undef
+      $tempbase                           = undef
+      $tmpdir                             = undef
     }
+    'RedHat': {
+      # Service settings
+      $clamd_service                      = 'clamd'
+      $config_dir                         = '/etc/amavisd'
+      $config_file                        = 'amavisd.conf'
+      $manage_epel                        = true
+      $service_name                       = 'amavisd'
+      $snmp_package_name                  = 'amavisd-new-snmp'
+      $snmp_service_name                  = 'amavisd-snmp'
+      $state_dir                          = '/var/run/amavisd'
+      $user_shell                         = '/sbin/nologin'
+
+      # Config settings
+      $addr_extension_bad_header_maps     = ['badh' ]
+      $addr_extension_banned_maps         = [ 'banned' ]
+      $addr_extension_spam_maps           = [ 'spam' ]
+      $addr_extension_virus_maps          = [ 'virus' ]
+      $banned_filename_re                 = [
+        "qr'^\\.(exe-ms|dll)$'",
+        "[ qr'^\\.(rpm|cpio|tar)$'       => 0 ]",
+        "qr'.\\.(pif|scr)$'i",
+        "qr'^application/x-msdownload$'i",
+        "qr'^application/x-msdos-program$'i",
+        "qr'^application/hta$'i",
+        "qr'^(?!cid:).*\\.[^./]*[A-Za-z][^./]*\\.\\s*(exe|vbs|pif|scr|bat|cmd|com|cpl|dll)[.\\s]*$'i",
+        "qr'.\\.(exe|vbs|pif|scr|cpl)$'i"
+      ]
+      $bounce_killer_score                = 100
+      $db_home                            = '$MYHOME/db'
+      $decoders                           = [
+        "['mail', \\&do_mime_decode]",
+        "['F',    \\&do_uncompress, ['unfreeze', 'freeze -d', 'melt', 'fcat'] ]",
+        "['Z',    \\&do_uncompress, ['uncompress', 'gzip -d', 'zcat'] ]",
+        "['gz',   \\&do_uncompress, 'gzip -d']",
+        "['gz',   \\&do_gunzip]",
+        "['bz2',  \\&do_uncompress, 'bzip2 -d']",
+        "['xz',   \\&do_uncompress, ['xzdec', 'xz -dc', 'unxz -c', 'xzcat'] ]",
+        "['lzma', \\&do_uncompress, ['lzmadec', 'xz -dc --format=lzma','lzma -dc', 'unlzma -c', 'lzcat', 'lzmadec'] ]",
+        "['lrz',  \\&do_uncompress, ['lrzip -q -k -d -o -', 'lrzcat -q -k'] ]",
+        "['lzo',  \\&do_uncompress, 'lzop -d']",
+        "['lz4',  \\&do_uncompress, ['lz4c -d'] ]",
+        "['rpm',  \\&do_uncompress, ['rpm2cpio.pl', 'rpm2cpio'] ]",
+        "[['cpio','tar'], \\&do_pax_cpio, ['pax', 'gcpio', 'cpio'] ]",
+        "['deb',  \\&do_ar, 'ar']",
+        "['rar',  \\&do_unrar, ['unrar', 'rar'] ]",
+        "['arj',  \\&do_unarj, ['unarj', 'arj'] ]",
+        "['arc',  \\&do_arc,   ['nomarch', 'arc'] ]",
+        "['zoo',  \\&do_zoo,   ['zoo', 'unzoo'] ]",
+        "['cab',  \\&do_cabextract, 'cabextract']",
+        "['tnef', \\&do_tnef]",
+        "[['zip','kmz'], \\&do_7zip,  ['7za', '7z'] ]",
+        "[['zip','kmz'], \\&do_unzip]",
+        "['7z', \\&do_7zip,  ['7zr', '7za', '7z'] ]",
+        "[[qw(gz bz2 Z tar)], \\&do_7zip,  ['7za', '7z'] ]",
+        "[[qw(xz lzma jar cpio arj rar swf lha iso cab deb rpm)], \\&do_7zip,  '7z' ]",
+        "['exe',  \\&do_executable, ['unrar','rar'], 'lha', ['unarj','arj'] ]"
+      ]
+      $defang_banned                      = 1
+      $defang_by_ccat                     = [
+        'CC_BADH.",3"',
+        'CC_BADH.",5"',
+        'CC_BADH.",6"'
+      ]
+      $defang_virus                       = 1
+      $do_syslog                          = 1
+      $enable_db                          = 1
+      $enable_dkim_signing                = 1
+      $enable_dkim_verification           = 1
+      $final_bad_header_destiny           = 'D_BOUNCE'
+      $final_banned_destiny               = 'D_BOUNCE'
+      $final_spam_destiny                 = 'D_DISCARD'
+      $final_virus_destiny                = 'D_DISCARD'
+      $include_score_sender_maps          = true
+      $inet_socket_bind                   = '127.0.0.1'
+      $inet_socket_port                   = [ 10024 ]
+      $interface_policy                   = {
+        '10026' => 'ORIGINATING',
+        'SOCK' => 'AM.PDP-SOCK'
+      }
+      $keep_decoded_original_maps         =  [
+        "qr'^MAIL$'",
+        "qr'^MAIL-UNDECIPHERABLE$'",
+        "qr'^(ASCII(?! cpio)|text|uuencoded|xxencoded|binhex)'i",
+      ]
+      $local_domains_maps                 = [ '.$mydomain' ]
+      $log_level                          = 0
+      $max_expansion_quota                = 500*1024*1024
+      $maxfiles                           = 3000
+      $maxlevels                          = 14
+      $max_servers                        = 2
+      $min_expansion_quota                = '100*1024'
+      $mydomain                           = 'example.com'
+      $myhome                             = '/var/spool/amavisd'
+      $mynetworks                         = [
+        '127.0.0.0/8',
+        '[::1]',
+        '[FE80::]/10',
+        '[FEC0::]/10',
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16'
+      ]
+      $nanny_details_level                = 2
+      $path                               = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin'
+      $penpals_bonus_score                = 8
+      $penpals_threshold_high             = '$sa_kill_level_deflt'
+      $policy_bank                        = {
+        'MYNETS' => {
+          originating           => 1,
+          os_fingerprint_method => 'undef'
+        },
+        'ORIGINATING' => {
+          originating                     => 1,
+          allow_disclaimers               => 1,
+          virus_admin_maps                => '["virusalert\@$mydomain"]',
+          spam_admin_maps                 => '["virusalert\@$mydomain"]',
+          warnbadhsender                  => 1,
+          forward_method                  => "'smtp:[127.0.0.1]:10027'",
+          smtpd_discard_ehlo_keywords     => "['8BITMIME']",
+          bypass_banned_checks_maps       => '[1]',
+          terminate_dsn_on_notify_success => 0
+        },
+        'AM.PDP-SOCK' => {
+          protocol => "'AM.PDP'",
+          auth_required_release => '0'
+        }
+      }
+      $sa_crediblefrom_dsn_cutoff_level   = 18
+      $sa_dsn_cutoff_level                = 10
+      $sa_kill_level_deflt                = '6.9'
+      $sa_local_tests_only                = 0
+      $sa_mail_body_size_limit            = '400*1024'
+      $sa_spam_subject_tag                = '***Spam*** '
+      $sa_tag_level_deflt                 = '2.0'
+      $sa_tag2_level_deflt                = '6.2'
+      $syslog_facility                    = 'mail'
+      $tempbase                           = '$MYHOME/tmp'
+      $tmpdir                             = '$TEMPBASE'
+
+    }
+    default: {
+      fail("Unsupported osfamily: ${::osfamily}")
+    }
+  }
 
 }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -4,14 +4,8 @@
 #
 # === Variables
 #
-# These variables from other classes are required for correct functionality:
-#
-# [*amavisd::_package_name*]
-#   This is used to provide repository dependencies to the package resource
-#
-# [*amavisd::_manage_epel*]
-#   This determines whether the *epel* class is included and whether the
-#   EPEL repository is managed using this module
+#  $amavisd::_manage_epel
+#  $amavisd::package_name
 #
 # === Authors
 #
@@ -19,27 +13,27 @@
 #
 # === Copyright
 #
-# Copyright 2016
+# Copyright 2018
 #
 class amavisd::repos {
 
-    case $::osfamily {
-        'Debian': {
-            require ::apt
+  case $::osfamily {
+    'Debian': {
+      require ::apt
 
-            Exec['apt_update'] -> Package[$amavisd::_package_name]
-        }
-        'RedHat': {
-            if ($::operatingsystem != 'Amazon') and ($::operatingsystem != 'Fedora') {
-                if ($amavisd::_manage_epel == true) {
-                    require ::epel
-
-                    Class['epel'] -> Package[$amavisd::_package_name]
-                }
-            }
-        }
-        default: {
-            fail("Unsupported osfamily: ${::osfamily}")
-        }
+      Exec['apt_update'] -> Package[$amavisd::package_name]
     }
+    'RedHat': {
+      if ($::operatingsystem != 'Amazon') and ($::operatingsystem != 'Fedora') {
+        if ($amavisd::_manage_epel == true) {
+          require ::epel
+
+          Class['epel'] -> Package[$amavisd::package_name]
+        }
+      }
+    }
+    default: {
+      fail("Unsupported osfamily: ${::osfamily}")
+    }
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,30 +4,38 @@
 #
 # === Authors
 #
+# === Variables
+#
+#  $amavisd::_clamd_service
+#  $amavisd::service_enable
+#  $amavisd::service_ensure
+#  $amavisd::_service_name
+#  $amavisd::watch_clamav
+#
 # Andrew Teixeira <teixeira@broadinstitute.org>
 #
 # === Copyright
 #
-# Copyright 2016
+# Copyright 2018
 #
 class amavisd::service {
 
-    if $amavisd::watch_clamav {
-        $svc_require   = Service[$amavisd::_clamd_service]
-        $svc_subscribe = [
-            Concat[$amavisd::config::amavis_conf],
-            Service[$clamav::clamd_service]
-        ]
-    } else {
-        $svc_require   = undef
-        $svc_subscribe = Concat[$amavisd::config::amavis_conf]
-    }
+  if $amavisd::watch_clamav {
+    $svc_require   = Service[$amavisd::_clamd_service]
+    $svc_subscribe = [
+      Concat[$amavisd::config::amavis_conf],
+      Service[$clamav::clamd_service]
+    ]
+  } else {
+    $svc_require   = undef
+    $svc_subscribe = Concat[$amavisd::config::amavis_conf]
+  }
 
-    service { 'amavisd_service':
-        ensure    => $amavisd::service_ensure,
-        enable    => $amavisd::service_enable,
-        name      => $amavisd::_service_name,
-        require   => $svc_require,
-        subscribe => $svc_subscribe
-    }
+  service { 'amavisd_service':
+    ensure    => $amavisd::service_ensure,
+    enable    => $amavisd::service_enable,
+    name      => $amavisd::_service_name,
+    require   => $svc_require,
+    subscribe => $svc_subscribe
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-amavisd",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "author": "Andrew Teixeira <teixeira@broadinstitute.org>",
   "summary": "Amavisd Puppet module",
   "license": "Apache-2.0",
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -19,7 +18,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -27,24 +25,23 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0 < 4.13.1"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0 < 5.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 1.0.2 < 2.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 < 3.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 3.0.0"}
+    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 < 5.0.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 2.2.1 < 3.0.0"}
   ],
   "requirements": [
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,7 +68,7 @@ describe 'amavisd' do
       end
 
       case facts[:osfamily]
-      when 'Debian'
+      when 'Debian', 'Ubuntu'
 
         context 'osfamily differences with defaults for all parameters' do
           it { should contain_class('apt') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 require 'rubygems'
-require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 
 include RspecPuppetFacts
+
+RSpec.configure do |c|
+    c.mock_with :rspec
+  end
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/vagrant_files/debian-stretch-init.sh
+++ b/vagrant_files/debian-stretch-init.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
-export PUPPET_GEM_VERSION='< 5'
-
-rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-nightly-puppetlabs-PC1
-yum -y install git puppet-agent vim
+wget -O /tmp/puppetlabs-release-pc1-stretch.deb https://apt.puppetlabs.com/puppetlabs-release-pc1-stretch.deb
+dpkg -i /tmp/puppetlabs-release-pc1-stretch.deb
+apt-get update
+apt-get install -yq build-essential curl git puppet-agent ruby ruby-dev vim
 mv /tmp/Gemfile /etc/puppetlabs/code/
 mv /tmp/hiera.yaml /etc/puppetlabs/code/
 mkdir -p /etc/puppetlabs/code/hieradata
@@ -14,8 +11,10 @@ mkdir -p /etc/puppetlabs/code/modules
 touch /etc/puppetlabs/code/hieradata/global.yaml
 gem install bundle librarian-puppet rake --no-rdoc --no-ri
 bundle config --global silence_root_warning 1
-cd /etc/puppetlabs/code || exit
-bundle install
 cd /etc/puppetlabs/code/modules/amavisd || exit
+bundle install
 rm -f Puppetfile.lock
 librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules
+# The ec2 fact has a broken timeout, so it will make each puppet run take
+# about 10 minutes if it exists.  So, make it not exist!
+rm -f /var/lib/gems/2.3.0/gems/facter-2.5.1/lib/facter/ec2/rest.rb

--- a/vagrant_files/ubuntu-bionic-init.sh
+++ b/vagrant_files/ubuntu-bionic-init.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
-export PUPPET_GEM_VERSION='< 5'
-
-rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-nightly-puppetlabs-PC1
-yum -y install git puppet-agent vim
+wget -O /tmp/puppet-release-bionic.deb https://apt.puppetlabs.com/puppet-release-bionic.deb
+dpkg -i /tmp/puppet-release-bionic.deb
+apt-get update
+apt-get install -yq build-essential curl git puppet-agent ruby ruby-dev vim
 mv /tmp/Gemfile /etc/puppetlabs/code/
 mv /tmp/hiera.yaml /etc/puppetlabs/code/
 mkdir -p /etc/puppetlabs/code/hieradata
@@ -14,8 +11,7 @@ mkdir -p /etc/puppetlabs/code/modules
 touch /etc/puppetlabs/code/hieradata/global.yaml
 gem install bundle librarian-puppet rake --no-rdoc --no-ri
 bundle config --global silence_root_warning 1
-cd /etc/puppetlabs/code || exit
-bundle install
 cd /etc/puppetlabs/code/modules/amavisd || exit
+bundle install
 rm -f Puppetfile.lock
 librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules


### PR DESCRIPTION
* Remove versions from `.fixtures.yml`
* Remove unnecessary lint disables from `Rakefile`
* Changed to a new box for Vagrant
* Updated the Vagrant init script
* Updated all Puppet manifests to 2 spaces (https://puppet.com/docs/puppet/5.5/style_guide.html)
* Removed all useless comments from the tops of the manifest files
* Updated `spec_helper.rb` due to changes in newer versions
* Move version to 2.0.0 due to deprecating Puppet 3
* Update the list of Ruby/Puppet versions tested in Travis
* Remove EOL operating systems from metadata
* More accurate comments at the tops of manifest files